### PR TITLE
Calendar pipeline plugin

### DIFF
--- a/algebraic-graphs-patch/CHANGELOG.md
+++ b/algebraic-graphs-patch/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/algebraic-graphs-patch/algebraic-graphs-patch.cabal
+++ b/algebraic-graphs-patch/algebraic-graphs-patch.cabal
@@ -1,47 +1,22 @@
 cabal-version:      2.4
-name:               emanote-core
+name:               algebraic-graphs-patch
 version:            0.1.0.0
 license:            AGPL-3.0-only
 author:             Sridhar Ratnakumar
 maintainer:         srid@srid.ca
-extra-source-files: CHANGELOEmanote.md
+extra-source-files: CHANGELOG.md
 
 library
   hs-source-dirs:     src
   exposed-modules:
-    Data.Conflict
-    Data.Conflict.Patch
-    Emanote.Graph
-    Emanote.Markdown.WikiLink
-    Emanote.Zk.Type
+    Algebra.Graph.Labelled.AdjacencyMap.Patch
 
   build-depends:
-    , aeson
     , algebraic-graphs
-    , async
     , base
-    , commonmark
-    , commonmark-extensions
-    , commonmark-pandoc
     , containers
-    , data-default
-    , directory
-    , filepath
-    , filepattern
-    , megaparsec
-    , pandoc-link-context
-    , pandoc-types
-    , parsec
-    , parser-combinators
-    , reflex
-    , reflex-dom-core
-    , reflex-dom-pandoc
+    , patch
     , relude
-    , shower
-    , tagged
-    , text
-    , time
-    , uri-encode
 
   default-extensions:
     NoImplicitPrelude

--- a/algebraic-graphs-patch/src/Algebra/Graph/Labelled/AdjacencyMap/Patch.hs
+++ b/algebraic-graphs-patch/src/Algebra/Graph/Labelled/AdjacencyMap/Patch.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Emanote.Graph.Patch where
+module Algebra.Graph.Labelled.AdjacencyMap.Patch where
 
 import qualified Algebra.Graph.Labelled.AdjacencyMap as AM
 import qualified Data.Map.Strict as Map
+import Data.Patch.Class (Patch (..))
 import qualified Data.Set as Set
-import Reflex.Patch.Class (Patch (..))
 import Relude
 
 -- | NOTE: Patching a graph may leave orphan vertices behind. Use

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -30,6 +30,7 @@ library
     , text
     , websockets
     , websockets-snap
+    , algebraic-graphs-patch
 
   exposed-modules:    Backend
   default-extensions:

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -3,6 +3,7 @@
 
 module Backend where
 
+import qualified Algebra.Graph.Labelled.AdjacencyMap.Patch as GP
 import Common.Api
 import Common.Route
 import qualified Data.Aeson as Aeson
@@ -13,7 +14,6 @@ import Data.Some (Some (..))
 import qualified Data.Text as T
 import qualified Emanote
 import qualified Emanote.Graph as G
-import qualified Emanote.Graph.Patch as GP
 import Emanote.Markdown.WikiLink
 import qualified Emanote.Markdown.WikiLink as W
 import qualified Emanote.Pipeline as Pipeline

--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,7 @@ project ./. ({ pkgs, hackGet, ... }: {
   packages = {
     emanote-core = hackGet ./emanote-core;
     emanote = hackGet ./emanote;
+    algebraic-graphs-patch = hackGet ./algebraic-graphs-patch;
     with-utf8 = hackGet ./dep/with-utf8;
     pandoc-link-context = hackGet ./dep/pandoc-link-context;
     reflex-dom-pandoc = hackGet ./dep/reflex-dom-pandoc;

--- a/doc/Features.md
+++ b/doc/Features.md
@@ -8,5 +8,7 @@
 - Link to notes that need not exist
   - Linking as `[[Foo]]` for example, will treat "Foo" as a legitimate note even if "Foo.md" does not exist on disk. This enables "tagging" a note with some folgezettel parent (eg. `#[[Review]]`) without being forced to create an empty Markdown file ("Review.md") on disk.
 - [[Pretty URLs]]
+- Pipeline plugins
+  - Calendar folgezettej
 - `IN-ROADMAP` Pandoc filters 
 - `IN-ROADMAP` Plugins (calendar, tasks, etc.)

--- a/emanote-core/src/Emanote/Graph.hs
+++ b/emanote-core/src/Emanote/Graph.hs
@@ -16,29 +16,28 @@ newtype Graph = Graph {unGraph :: AM.AdjacencyMap E V}
 empty :: Graph
 empty = Graph AM.empty
 
-postSetWithLabel :: (Ord a, Monoid e) => a -> AM.AdjacencyMap e a -> [(e, a)]
-postSetWithLabel v g =
-  let es = toList $ AM.postSet v g
-   in es <&> \v1 ->
-        (,v1) $ AM.edgeLabel v v1 g
-
-preSetWithLabel :: (Ord a, Monoid e) => a -> AM.AdjacencyMap e a -> [(e, a)]
-preSetWithLabel v g =
-  let es = toList $ AM.preSet v g
-   in es <&> \v0 ->
-        (,v0) $ AM.edgeLabel v0 v g
-
 connectionsOf :: (Directed WikiLinkLabel -> Bool) -> V -> Graph -> [(E', V)]
-connectionsOf f v graph =
+connectionsOf f x graph =
   go UserDefinedDirection postSetWithLabel
     <> go ReverseDirection preSetWithLabel
   where
     go dir pSet =
       concat $
-        flip fmap (pSet v (unGraph graph)) $ \(es, t) ->
+        flip fmap (pSet x (unGraph graph)) $ \(es, t) ->
           flip mapMaybe es $ \(lbl, ctx) -> do
             guard $ f (dir lbl)
             pure ((lbl, ctx), t)
+    postSetWithLabel :: (Ord a, Monoid e) => a -> AM.AdjacencyMap e a -> [(e, a)]
+    postSetWithLabel v g =
+      let es = toList $ AM.postSet v g
+       in es <&> \v1 ->
+            (,v1) $ AM.edgeLabel v v1 g
+
+    preSetWithLabel :: (Ord a, Monoid e) => a -> AM.AdjacencyMap e a -> [(e, a)]
+    preSetWithLabel v g =
+      let es = toList $ AM.preSet v g
+       in es <&> \v0 ->
+            (,v0) $ AM.edgeLabel v0 v g
 
 -- | Filter the graph to contain only edges satisfying the predicate
 filterBy :: (Directed WikiLinkLabel -> Bool) -> Graph -> Graph

--- a/emanote-core/src/Emanote/Graph/Patch.hs
+++ b/emanote-core/src/Emanote/Graph/Patch.hs
@@ -35,10 +35,16 @@ instance Patch PatchGraph where
         m Bool
       patchVertex (v, mes) =
         case mes of
-          Nothing ->
+          Nothing -> do
+            g <- get
             gets (AM.hasVertex v) >>= \case
-              True -> modify (AM.removeVertex v) >> pure True
-              False -> pure False
+              True -> do
+                if Set.null $ AM.preSet v g
+                  then -- Delete only if no other vertex is connecting to us.
+                    modify (AM.removeVertex v) >> pure True
+                  else pure False
+              False ->
+                pure False
           Just es -> do
             g <- get
             let esOld = toList $ postSetWithLabel v g

--- a/emanote-core/src/Emanote/Graph/Patch.hs
+++ b/emanote-core/src/Emanote/Graph/Patch.hs
@@ -73,6 +73,12 @@ instance Patch PatchGraph where
                 -- and checked elsewhere. See patchedGraphVertexSet below.
                 pure True
 
+-- | Create a patch graph that that will "copy" the given graph when applied as
+-- a patch to an empty graph.
+asPatchGraph :: Graph -> PatchGraph
+asPatchGraph (Graph am) =
+  PatchGraph $ Just . fmap swap . Map.toList <$> AM.adjacencyMap am
+
 -- | Return the vertices in the graph with the given pruning function.
 --
 -- Use this function to accomodate for PatchGraph's idiosyncratic behaviour of

--- a/emanote/emanote.cabal
+++ b/emanote/emanote.cabal
@@ -18,6 +18,7 @@ library
 
   build-depends:
     , algebraic-graphs
+    , algebraic-graphs-patch
     , async
     , base
     , commonmark

--- a/emanote/src/Emanote/Pipeline.hs
+++ b/emanote/src/Emanote/Pipeline.hs
@@ -4,6 +4,7 @@
 module Emanote.Pipeline (run, runNoMonitor) where
 
 import qualified Algebra.Graph.Labelled.AdjacencyMap as AM
+import qualified Algebra.Graph.Labelled.AdjacencyMap.Patch as G
 import qualified Commonmark.Syntax as CM
 import Data.Conflict (Conflict (..))
 import qualified Data.Conflict as Conflict
@@ -13,7 +14,6 @@ import Data.Tagged (Tagged (..))
 import Emanote.FileSystem (PathContent (..))
 import qualified Emanote.FileSystem as FS
 import qualified Emanote.Graph as G
-import qualified Emanote.Graph.Patch as G
 import qualified Emanote.Markdown as M
 import qualified Emanote.Markdown.WikiLink.Parser as M
 import Emanote.Zk (Zk (Zk))

--- a/emanote/src/Emanote/Pipeline.hs
+++ b/emanote/src/Emanote/Pipeline.hs
@@ -159,10 +159,8 @@ pipeGraph = do
                 Just es ->
                   G.ModifyGraph_ReplaceVertexWithSuccessors k (first one <$> es)
 
--- | Tag daily notes with month zettels ("2020-02").
---
--- The month zettels themselves will be tagged with year zettels ("2020"), if
--- the month zettel exists on disk (otherwise won't).
+-- | Tag daily notes with month zettels ("2020-02"), which are tagged further
+-- with year zettels ("2020").
 pipeCreateCalendar ::
   Reflex t =>
   Incremental t (G.PatchGraph G.E G.V) ->

--- a/emanote/src/Emanote/Pipeline.hs
+++ b/emanote/src/Emanote/Pipeline.hs
@@ -159,7 +159,7 @@ pipeGraph = do
                 Just es ->
                   G.ModifyGraph_ReplaceVertexWithSuccessors k (first one <$> es)
 
--- | WIP: Tag daily notes with month zettels ("2020-02").
+-- | Tag daily notes with month zettels ("2020-02").
 --
 -- The month zettels themselves will be tagged with year zettels ("2020"), if
 -- the month zettel exists on disk (otherwise won't).
@@ -180,11 +180,13 @@ pipeCreateCalendar =
               flip mapMaybe (Set.toList $ G.modifiedOrAddedVertices d) $ \wId -> do
                 (Tagged -> parent) <- parse wIdParser (untag wId)
                 pure $ G.ModifyGraph_AddEdge (one (M.WikiLinkLabel_Tag, mempty)) wId parent
-       in -- FIXME: Year entries won't be created if months zettels don't exist on disk
-          mconcat
+          monthDiff = liftNote monthFromDate diff
+          -- Include monthDiff here, so as to 'lift' those ghost month zettels further.
+          yearDiff = liftNote yearFromMonth (diff <> monthDiff)
+       in mconcat
             [ diff,
-              liftNote monthFromDate diff,
-              liftNote yearFromMonth diff
+              monthDiff,
+              yearDiff
             ]
     yearFromMonth :: M.Parsec Void Text Text
     yearFromMonth = do

--- a/emanote/src/Emanote/Zk.hs
+++ b/emanote/src/Emanote/Zk.hs
@@ -4,7 +4,7 @@ module Emanote.Zk where
 
 import Control.Concurrent (forkIO)
 import qualified Control.Concurrent.STM as STM
-import Emanote.Graph (Graph)
+import Emanote.Graph (E, Graph (..), V)
 import Emanote.Graph.Patch (PatchGraph)
 import qualified Emanote.Markdown.WikiLink as M
 import Emanote.Zk.Type
@@ -15,7 +15,7 @@ import Relude
 
 data Zk = Zk
   { _zk_zettels :: TIncremental (PatchMap M.WikiLinkID Zettel),
-    _zk_graph :: TIncremental PatchGraph,
+    _zk_graph :: TIncremental (PatchGraph E V),
     _zk_processStateRev :: TVar Rev
   }
 
@@ -33,7 +33,7 @@ getZettels =
 
 getGraph :: MonadIO m => Zk -> m Graph
 getGraph =
-  TInc.readValue . _zk_graph
+  fmap Graph . TInc.readValue . _zk_graph
 
 getRev :: MonadIO m => Zk -> m Rev
 getRev =

--- a/emanote/src/Emanote/Zk.hs
+++ b/emanote/src/Emanote/Zk.hs
@@ -2,10 +2,10 @@
 
 module Emanote.Zk where
 
+import Algebra.Graph.Labelled.AdjacencyMap.Patch (PatchGraph)
 import Control.Concurrent (forkIO)
 import qualified Control.Concurrent.STM as STM
 import Emanote.Graph (E, Graph (..), V)
-import Emanote.Graph.Patch (PatchGraph)
 import qualified Emanote.Markdown.WikiLink as M
 import Emanote.Zk.Type
 import Reflex (PatchMap)


### PR DESCRIPTION
Adds folgezettel parents to daily notes, to form a calendar tree.

Eg: `2021-02-11.md` is made to branch under `2021-02` (even if "2020-02.md" doesn't exist on disk), which in turn is made to branch under `2021`.